### PR TITLE
Specify that the page supports both light and dark color schemes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <title>Firefox Nightly changelog</title>
 <meta name="viewport" content="width=device-width"/>
 <meta charset="UTF-8">
+<meta name="color-scheme" content="light dark">
 <script type="text/javascript" src="js/main.js"></script>
 <link href="css/main.css" rel="stylesheet" type="text/css"/>
 <link rel="icon" href="favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1779874

Otherwise the "used" color-scheme of the content is light, which means
that we start propagating the light color-scheme preference to the SVG.